### PR TITLE
Public StepZen GraphQL Response

### DIFF
--- a/components/lib/mocks/coinranking.json
+++ b/components/lib/mocks/coinranking.json
@@ -1,58 +1,62 @@
 {
-  "status": "success",
-  "data": {
-    "referenceCurrencyRate": 1,
-    "totalCoins": 15550,
-    "totalMarkets": 30203,
-    "totalExchanges": 177,
-    "totalMarketCap": "1101050469524",
-    "total24hVolume": "77969094152",
-    "btcDominance": 37.739399005355274,
-    "bestCoins": [
-      {
-        "uuid": "cKExCczgV",
-        "symbol": "UST",
-        "name": "TerraUSD",
-        "iconUrl": "https://cdn.coinranking.com/mtb0IvtcM/terrausd.png",
-        "coinrankingUrl": "https://coinranking.com/coin/cKExCczgV+terrausd-ust"
-      },
-      {
-        "uuid": "ZIXroLSIK",
-        "symbol": "NU",
-        "name": "NuCypher",
-        "iconUrl": "https://cdn.coinranking.com/EDLGxX9Wk/nucypher.svg",
-        "coinrankingUrl": "https://coinranking.com/coin/ZIXroLSIK+nucypher-nu"
-      },
-      {
-        "uuid": "Knsels4_Ol-Ny",
-        "symbol": "ATOM",
-        "name": "Cosmos",
-        "iconUrl": "https://cdn.coinranking.com/HJzHboruM/atom.svg",
-        "coinrankingUrl": "https://coinranking.com/coin/Knsels4_Ol-Ny+cosmos-atom"
-      }
-    ],
-    "newestCoins": [
-      {
-        "uuid": "GjumCDbk_",
-        "symbol": "SERG",
-        "name": "Seiren Games Network",
-        "iconUrl": "https://cdn.coinranking.com/RT2hkPtoO/21487.png",
-        "coinrankingUrl": "https://coinranking.com/coin/GjumCDbk_+seirengamesnetwork-serg"
-      },
-      {
-        "uuid": "u9vE9srdx",
-        "symbol": "SEON",
-        "name": "SeedOn",
-        "iconUrl": "https://cdn.coinranking.com/k58eFxcMA/13360.png",
-        "coinrankingUrl": "https://coinranking.com/coin/u9vE9srdx+seedon-seon"
-      },
-      {
-        "uuid": "HvdbkrCio",
-        "symbol": "SEDA",
-        "name": "SEDA",
-        "iconUrl": "https://cdn.coinranking.com/tXqp_VP_-/18592.png",
-        "coinrankingUrl": "https://coinranking.com/coin/HvdbkrCio+seda-seda"
-      }
-    ]
-  }
+	"data": {
+		"coinrankingQuery": {
+			"data": {
+				"bestCoins": [
+					{
+						"coinrankingUrl": "https://coinranking.com/coin/C6ddYx4P1+golem-glm",
+						"iconUrl": "https://cdn.coinranking.com/vEGBbrz3E/glm.png",
+						"name": "Golem",
+						"symbol": "GLM",
+						"uuid": "C6ddYx4P1"
+					},
+					{
+						"coinrankingUrl": "https://coinranking.com/coin/DLr6VeXg72S1+synapse-syn",
+						"iconUrl": "https://cdn.coinranking.com/1lQoaECjp/e_fZt-du_400x400.png",
+						"name": "Synapse",
+						"symbol": "SYN",
+						"uuid": "DLr6VeXg72S1"
+					},
+					{
+						"coinrankingUrl": "https://coinranking.com/coin/DJdvWtzBV+synapseprotocol-syn",
+						"iconUrl": "https://cdn.coinranking.com/6nj8DY8Ab/TMzMKnlB_400x400.png",
+						"name": "Synapse Protocol",
+						"symbol": "SYN*",
+						"uuid": "DJdvWtzBV"
+					}
+				],
+				"btcDominance": 35.9129417930894,
+				"newestCoins": [
+					{
+						"coinrankingUrl": "https://coinranking.com/coin/wffmSQ5KHQ+wldycoin-wldy",
+						"iconUrl": "https://cdn.coinranking.com/UZMmA9Q2_/wildernessp2e_32.png",
+						"name": "WLDY Coin",
+						"symbol": "WLDY",
+						"uuid": "wffmSQ5KHQ"
+					},
+					{
+						"coinrankingUrl": "https://coinranking.com/coin/AzQZ2Gg1F+usd-usd",
+						"iconUrl": "https://cdn.coinranking.com/-Nkr6R1lZ/20317.png",
+						"name": "USD+",
+						"symbol": "USD",
+						"uuid": "AzQZ2Gg1F"
+					},
+					{
+						"coinrankingUrl": "https://coinranking.com/coin/N9UZ1gFBW+onebtc-onebtc",
+						"iconUrl": "https://cdn.coinranking.com/wlOqdNQYn/19356.png",
+						"name": "oneBTC",
+						"symbol": "ONEBTC",
+						"uuid": "N9UZ1gFBW"
+					}
+				],
+				"referenceCurrencyRate": 1,
+				"total24hVolume": 74784952309,
+				"totalCoins": 15659,
+				"totalExchanges": 173,
+				"totalMarketCap": 1023570266816,
+				"totalMarkets": 30134
+			},
+			"status": "success"
+		}
+	}
 }


### PR DESCRIPTION
Show the GraphQL response rather than the REST response. 

In the blog, it is in order to where the response should be wrapped by `{ data { coinrankingQuery {} } }`